### PR TITLE
Add next button and fix PlayClip

### DIFF
--- a/Jukebox/Jukebox/Form1.Designer.cs
+++ b/Jukebox/Jukebox/Form1.Designer.cs
@@ -40,6 +40,7 @@ namespace Jukebox
             this.axWindowsMediaPlayer1 = new AxWMPLib.AxWindowsMediaPlayer();
             this.Timer = new System.Windows.Forms.Timer(this.components);
             this.ShuffleBox = new System.Windows.Forms.CheckBox();
+            this.nextBtn = new System.Windows.Forms.Button();
             ((System.ComponentModel.ISupportInitialize)(this.axWindowsMediaPlayer1)).BeginInit();
             this.SuspendLayout();
             // 
@@ -128,11 +129,22 @@ namespace Jukebox
             this.ShuffleBox.UseVisualStyleBackColor = true;
             this.ShuffleBox.CheckedChanged += new System.EventHandler(this.ShuffleBox_CheckedChanged);
             // 
+            // nextBtn
+            // 
+            this.nextBtn.Location = new System.Drawing.Point(498, 74);
+            this.nextBtn.Name = "nextBtn";
+            this.nextBtn.Size = new System.Drawing.Size(75, 23);
+            this.nextBtn.TabIndex = 8;
+            this.nextBtn.Text = "button1";
+            this.nextBtn.UseVisualStyleBackColor = true;
+            this.nextBtn.Click += new System.EventHandler(this.nextBtn_Click);
+            // 
             // Form1
             // 
             this.AutoScaleDimensions = new System.Drawing.SizeF(6F, 13F);
             this.AutoScaleMode = System.Windows.Forms.AutoScaleMode.Font;
             this.ClientSize = new System.Drawing.Size(933, 449);
+            this.Controls.Add(this.nextBtn);
             this.Controls.Add(this.ShuffleBox);
             this.Controls.Add(this.CurrentSongNameLbl);
             this.Controls.Add(this.NowPlaying);
@@ -159,6 +171,7 @@ namespace Jukebox
         private AxWMPLib.AxWindowsMediaPlayer axWindowsMediaPlayer1;
         private System.Windows.Forms.Timer Timer;
         private System.Windows.Forms.CheckBox ShuffleBox;
+        private System.Windows.Forms.Button nextBtn;
     }
 }
 

--- a/Jukebox/Jukebox/Form1.cs
+++ b/Jukebox/Jukebox/Form1.cs
@@ -74,10 +74,24 @@ namespace Jukebox
             EndClip();
             PlayBtn.Text = "Play";
         }
+        private void nextBtn_Click(object sender, EventArgs e)
+        {
+            //Next button moves the SongSelector combobox to the next song and reverts back to beginning of list if at the end
+            if(ShuffleBox.Checked == false)
+            {
+                if (SongSelector.SelectedIndex == SongSelector.Items.Count -1)
+                    SongSelector.SelectedIndex = 0;
+                else
+                    SongSelector.SelectedIndex = (SongSelector.SelectedIndex + 1);
+                currentSong = SongSelector.Text;
+                PlayClip(SongSelector.SelectedIndex);
+            }
+            //Add this section once shuffle is working correctly.
+        }
 
         private void PlayClip(int index)
         {
-            player.currentMedia = player.currentMedia;
+            player.URL = fileDirectory + currentSong + ".mp3";
             player.controls.play();
             CurrentSongNameLbl.Text = player.currentMedia.name;
             PlayBtn.Text = "Pause";


### PR DESCRIPTION
I added a next button that will play the next song in the combo box. I don't know how this will work with shuffle but it might be better to shuffle the combobox contents instead of the playlist itself in the end.
Additionally, since the last patch the PlayClip function wasn't doing anything once you select another song. I provided a fix for the time being although I don't know if you plan on changing it based on how playlists work.